### PR TITLE
Update transcripts to pull from new proxy

### DIFF
--- a/app/Http/Controllers/VideoController.php
+++ b/app/Http/Controllers/VideoController.php
@@ -84,7 +84,7 @@ class VideoController extends Controller
             'description' => $video['description'],
             'title' => $video['title'],
             'date' => date('M d, Y', strtotime($video['date_recorded'])),
-            'trackUrl' => config('app.datastore_url') . 'videos/' . $id . '/transcript?format=vtt',
+            'trackUrl' => '/api/videos/' . $id . '/transcript?format=vtt',
         ]);
     }
 

--- a/resources/js/components/video/Video.vue
+++ b/resources/js/components/video/Video.vue
@@ -445,7 +445,7 @@ export default {
     updateVideo() {
       this.setVideoSource(this.video.src);
       this.track = {
-        src: `${this.datastore}videos/${this.$route.params.id}/transcript?format=vtt`,
+        src: `/api/videos/${this.$route.params.id}/transcript?format=vtt`,
         kind: 'captions',
         language: 'en',
         label: 'English',
@@ -485,7 +485,7 @@ export default {
     },
     fetchTranscript() {
       axios
-        .get(`${this.datastore}videos/${this.$route.params.id}/transcript?format=json`)
+        .get(`/api/videos/${this.$route.params.id}/transcript?format=json`)
         .then((response) => {
           // Group word level data into paragraph level data.
           const { words, speakers } = response.data;

--- a/resources/js/components/video/VideoEmbed.vue
+++ b/resources/js/components/video/VideoEmbed.vue
@@ -76,7 +76,7 @@ export default {
     setVideo() {
       this.setVideoSource(this.video.src);
       this.track = {
-        src: `${this.datastore}videos/${this.video.asset_id}/transcript?format=vtt`,
+        src: `/api/videos/${this.video.asset_id}/transcript?format=vtt`,
         kind: 'captions',
         language: 'en',
         label: 'English',


### PR DESCRIPTION
Our remote VTT text tracks wouldn't load in Firefox and Safari sure to CORS errors, so I've adding a proxy_pass handler for all transcript requests to the nginx config for the front end. These changes update the links used to get transcripts to reflect that.

Those nginx changes are tracked in the configuration repository.