### PR TITLE
Fix for date filter not showing 2021

### DIFF
--- a/resources/js/components/CurrentSearch.vue
+++ b/resources/js/components/CurrentSearch.vue
@@ -95,7 +95,7 @@ export default {
       return queryStr === '' ? `${queryStr}${param}` : `${queryStr}&${param}`;
     },
     getValue(item, type) {
-      return type === 'date' ? new Date(item.key_as_string).getFullYear() : item.key;
+      return type === 'date' ? new Date(item.key_as_string).getUTCFullYear() : item.key;
     },
   },
 };

--- a/resources/js/components/SearchFacet.vue
+++ b/resources/js/components/SearchFacet.vue
@@ -88,7 +88,7 @@ export default {
       return this.activeFacets[key] && (this.activeFacets[key] === value || this.activeFacets[key].includes(value));
     },
     getValue(item, type) {
-      return type === 'date' ? new Date(item.key_as_string).getFullYear() : item.key;
+      return type === 'date' ? new Date(item.key_as_string).getUTCFullYear() : item.key;
     },
   },
 };

--- a/resources/js/components/SearchableFacet.vue
+++ b/resources/js/components/SearchableFacet.vue
@@ -165,7 +165,7 @@ export default {
       && (this.activeFacets[key] === value || this.activeFacets[key].includes(value));
     },
     getValue(item, type) {
-      return type === 'date' ? new Date(item.key_as_string).getFullYear() : item.key;
+      return type === 'date' ? new Date(item.key_as_string).getUTCFullYear() : item.key;
     },
   },
 };


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/178733460

To test, set your computer Timezone to PDT (UTC-07). 